### PR TITLE
Fixed some problems with MOD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,9 @@ __pycache__/
 
 # Custom
 Xrns2XMod/libs
+/Bass.Net.dll
+/ICSharpCode.SharpZipLib.dll
+/Nini.dll
+/libbass.so
+/libbassflac.so
+/libbassmix.so

--- a/Xrns2XMod/BassWrapper.cs
+++ b/Xrns2XMod/BassWrapper.cs
@@ -11,6 +11,8 @@ namespace Xrns2XMod
 {
     public static class BassWrapper
     {
+		static int testCnt = 0;
+
         public static void InitResources(IntPtr win, string bassEmail, string bassCode)
         {
             string targetPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
@@ -49,8 +51,15 @@ namespace Xrns2XMod
         {
             int handle;
 
+			Console.WriteLine ("GetBassTream " + testCnt + " "+ input.Stream.Length);
+
             Stream stream = input.Stream;
 
+			stream.Seek(0, System.IO.SeekOrigin.Begin);
+
+			using (FileStream file = new FileStream("getBassStream"+testCnt+".bin", FileMode.Create, System.IO.FileAccess.Write))
+				stream.CopyTo(file);
+			
             stream.Seek(0, System.IO.SeekOrigin.Begin);
 
             byte[] buffer = Utility.GetBytesFromStream(stream, stream.Length);
@@ -66,13 +75,15 @@ namespace Xrns2XMod
 
             switch (input.Format)
             {
-                case FORMAT.WAV:
+				case FORMAT.WAV:
                 case FORMAT.AIFF:
                 case FORMAT.MP3:
                 case FORMAT.OGG:
+					Console.WriteLine ("OGG");
                     actionStreamCreateFile = Bass.BASS_StreamCreateFile;
                     break;
                 case FORMAT.FLAC:
+					Console.WriteLine ("FLAC");
                     actionStreamCreateFile = BassFlac.BASS_FLAC_StreamCreateFile;                    
                     break;
                 case FORMAT.AAC:
@@ -134,7 +145,7 @@ namespace Xrns2XMod
         public static BASS_CHANNELINFO GetBassChannelInfo(int handle)
         {
             BASS_CHANNELINFO output = Bass.BASS_ChannelGetInfo(handle);
-
+			Console.WriteLine ("BASS_CHANNELINFO " + output.ToString());
             return output;
         }
 
@@ -155,6 +166,14 @@ namespace Xrns2XMod
             // total data written to the new byte[] buffer
             int totalDataWritten = Bass.BASS_ChannelGetData(handle, buffer, (int)sampleLength);
 
+			using (BinaryWriter writerRaw = new BinaryWriter (File.Open ("fileRaw" + testCnt + ".bin", FileMode.Create)))
+			{
+				for (uint i = 0; i < totalDataWritten; i++)
+				{
+					writerRaw.Write(buffer[i]);
+				}
+			}
+			
             MemoryStream inputSample = new MemoryStream(buffer);
 
             MemoryStream outputStream = new MemoryStream();
@@ -163,31 +182,45 @@ namespace Xrns2XMod
 
             BinaryWriter writer = new BinaryWriter(outputStream);
 
-            int delta = 0;
+			Console.WriteLine ("sampleLen " + sampleLength);
 
-            byte oldValue = (byte)128;
-
+			/*
+			inputSample.Seek(0, SeekOrigin.Begin);
+			using (FileStream file = new FileStream("file"+testCnt+".bin", FileMode.Create, System.IO.FileAccess.Write))
+				inputSample.CopyTo(file);
+			*/
+			inputSample.Seek(0, SeekOrigin.Begin);
+			testCnt++;
+            
+			BinaryWriter writer2 = new BinaryWriter (File.Open ("fileB" + testCnt + ".bin", FileMode.Create));
+			BinaryWriter writer3 = new BinaryWriter (File.Open ("fileD" + testCnt + ".bin", FileMode.Create));
+				
             // Amiga ProTracker compatibility
             // all samples with no loop should begin with two bytes of 0 value (Thanks to Jojo of OpenMPT for the hints)            
             if (ptCompatibility)
             {
                 for (int i = 0; i < 2; i++)
                 {
-                    byte value = reader.ReadByte();
-                    if (value != 128)
+					short value = reader.ReadInt16();
+                    if (value != 0)
                         writer.Write((sbyte)0);
                 }
 
                 inputSample.Seek(0, SeekOrigin.Begin);
             }
 
-            for (uint i = 0; i < totalDataWritten; i++)
+			Console.WriteLine ("totalDataWritten " + totalDataWritten);
+
+            for (uint i = 0; i < totalDataWritten; i+=2)
             {
-                byte newValue = reader.ReadByte();
-                delta += (newValue - oldValue);
-                oldValue = newValue;
-                writer.Write((sbyte)delta);
+				short value = reader.ReadInt16();
+				sbyte newValue = (sbyte)(value/256);
+                writer.Write(newValue);
+				writer2.Write (newValue);
             }
+
+			writer2.Close();
+			writer3.Close();
 
             // sample length must be even, because its value is stored divided by 2
             if (totalDataWritten % 2 != 0)
@@ -215,8 +248,9 @@ namespace Xrns2XMod
         {
             BASSFlag bassFlag = BASSFlag.BASS_STREAM_DECODE;
 
+
             if (res == 8)
-                bassFlag |= BASSFlag.BASS_SAMPLE_8BITS;
+				bassFlag |= BASSFlag.BASS_SAMPLE_8BITS;
 
             // this will be the final mixer output stream being played   
             int mixer = BassMix.BASS_Mixer_StreamCreate(freq, chans, bassFlag);
@@ -224,6 +258,7 @@ namespace Xrns2XMod
             // add channel to mixer
             bool isMixerGood = BassMix.BASS_Mixer_StreamAddChannel(mixer, handle, BASSFlag.BASS_MIXER_NORAMPIN);
 
+			Console.WriteLine (freq + " "+chans+" "+res+" isMixerGood " + isMixerGood);
             return mixer;
         }        
 

--- a/Xrns2XMod/BassWrapper.cs
+++ b/Xrns2XMod/BassWrapper.cs
@@ -208,9 +208,9 @@ namespace Xrns2XMod
 
                 inputSample.Seek(0, SeekOrigin.Begin);
             }
-
+#if DEBUG
             Console.WriteLine ("totalDataWritten " + totalDataWritten);
-
+#endif
             for (uint i = 0; i < totalDataWritten; i += 2)
             {
                 short value = reader.ReadInt16 ();

--- a/Xrns2XMod/ModConverter.cs
+++ b/Xrns2XMod/ModConverter.cs
@@ -210,10 +210,8 @@ namespace Xrns2XMod
                         // 1) same as original
                         // 2) taken from song settings                        
                         int sampleRate = freqC3;
-						Console.WriteLine("int sampleRate = freqC3; "+ sampleRate);
-
+                        
                         int freqFromIni = instruments[ci].Samples[0].SampleFreq;
-
 
                         if (freqFromIni > 0)
                         {
@@ -221,24 +219,26 @@ namespace Xrns2XMod
                             sampleRate = freqFromIni;
                         }
                         else
-                            sampleRate = bassChannelInfo.freq;
-                        
+                        {
+                            OnReportProgress (new EventReportProgressArgs (String.Format ("Sample {0} frequency stays C3 frequency {1} Hz", (ci + 1), sampleRate), MsgType.INFO));
+                            sampleRate = freqC3;
+                        }
 
-						Console.WriteLine("2 sampleRate "+ sampleRate+ "   sampleLength "+ sampleLength);
-                        int mixer = BassWrapper.PlugChannelToMixer(handle, sampleRate, 1, 16);
-						Console.WriteLine("bassChannelInfo.freq " + bassChannelInfo.freq);
-						Console.WriteLine("bassChannelInfo.chans " + bassChannelInfo.chans);
-						Console.WriteLine("origres " + origres);
-
-						//int mixer = BassWrapper.PlugChannelToMixer(handle, bassChannelInfo.freq, bassChannelInfo.chans, 8);
-						//int mixer = BassWrapper.PlugChannelToMixer(handle, bassChannelInfo.freq, bassChannelInfo.chans, 16);
+#if DEBUG
+                        Console.WriteLine("sampleRate "+ sampleRate+ "   sampleLength "+ sampleLength);
+                        Console.WriteLine("bassChannelInfo.freq " + bassChannelInfo.freq);
+                        Console.WriteLine("bassChannelInfo.chans " + bassChannelInfo.chans);
+                        Console.WriteLine("origres " + origres);
+#endif
+                        //Enforce 16 Bit Samples here as 8 Bit samples are corrupted (only on Linux?).
+                        //The 8 least significant bits are removed later.
+                        int mixer = BassWrapper.PlugChannelToMixer (handle, sampleRate, 1, 16);
 
                         if (Settings.VolumeScalingMode == VOLUME_SCALING_MODE.SAMPLE && instruments[ci].Samples[0].Volume != 1.0f)
                         {
                             OnReportProgress(new EventReportProgressArgs(String.Format("Ramping sample volume to value {0}", instruments[ci].Samples[0].Volume)));
                             BassWrapper.AdjustSampleVolume(handle, mixer, instruments[ci].Samples[0].Volume);
                         }
-                        
 
                         Stream stream = BassWrapper.GetModEncodedSample(mixer, sampleLength, Settings.ForceProTrackerCompatibility);
 

--- a/Xrns2XMod/ModConverter.cs
+++ b/Xrns2XMod/ModConverter.cs
@@ -210,8 +210,10 @@ namespace Xrns2XMod
                         // 1) same as original
                         // 2) taken from song settings                        
                         int sampleRate = freqC3;
-                        
+						Console.WriteLine("int sampleRate = freqC3; "+ sampleRate);
+
                         int freqFromIni = instruments[ci].Samples[0].SampleFreq;
+
 
                         if (freqFromIni > 0)
                         {
@@ -222,13 +224,21 @@ namespace Xrns2XMod
                             sampleRate = bassChannelInfo.freq;
                         
 
-                        int mixer = BassWrapper.PlugChannelToMixer(handle, sampleRate, 1, 8);
+						Console.WriteLine("2 sampleRate "+ sampleRate+ "   sampleLength "+ sampleLength);
+                        int mixer = BassWrapper.PlugChannelToMixer(handle, sampleRate, 1, 16);
+						Console.WriteLine("bassChannelInfo.freq " + bassChannelInfo.freq);
+						Console.WriteLine("bassChannelInfo.chans " + bassChannelInfo.chans);
+						Console.WriteLine("origres " + origres);
+
+						//int mixer = BassWrapper.PlugChannelToMixer(handle, bassChannelInfo.freq, bassChannelInfo.chans, 8);
+						//int mixer = BassWrapper.PlugChannelToMixer(handle, bassChannelInfo.freq, bassChannelInfo.chans, 16);
 
                         if (Settings.VolumeScalingMode == VOLUME_SCALING_MODE.SAMPLE && instruments[ci].Samples[0].Volume != 1.0f)
                         {
                             OnReportProgress(new EventReportProgressArgs(String.Format("Ramping sample volume to value {0}", instruments[ci].Samples[0].Volume)));
                             BassWrapper.AdjustSampleVolume(handle, mixer, instruments[ci].Samples[0].Volume);
                         }
+                        
 
                         Stream stream = BassWrapper.GetModEncodedSample(mixer, sampleLength, Settings.ForceProTrackerCompatibility);
 

--- a/Xrns2XModCmd/Program.cs
+++ b/Xrns2XModCmd/Program.cs
@@ -299,7 +299,12 @@ namespace Xrns2XModCmd
 
                     //MainFactory.InitResources(IntPtr.Zero, bassEmail, bassCode);
 
-                    Console.CursorTop++;
+                    /*
+                    ** Slamy: Moving the cursor like this causes problems on Mono.
+                    ** It says "fixing "Value must be positive and below the buffer height.""
+                    ** But it doesn't seems to be necessary anyway?
+                    */
+                    //Console.CursorTop++;
 
                     Console.WriteLine("Reading xrns data...");
 

--- a/Xrns2XModCmd/Program.cs
+++ b/Xrns2XModCmd/Program.cs
@@ -301,8 +301,8 @@ namespace Xrns2XModCmd
 
                     /*
                     ** Slamy: Moving the cursor like this causes problems on Mono.
-                    ** It says "fixing "Value must be positive and below the buffer height.""
-                    ** But it doesn't seems to be necessary anyway?
+                    ** It says 'fixing "Value must be positive and below the buffer height."'
+                    ** But it doesn't seems to be necessary anyway? I'll comment it out.
                     */
                     //Console.CursorTop++;
 


### PR DESCRIPTION
I believe that I've added more debugging code than actually fixing problems.
But hey. Maybe I still need it later on if something goes wrong again.

The problem with the strange "Value must be positive message" was fixed.
MOD samples are generated using 16 Bit BASS samples instead of 8 Bit. This fixes this strange periodic noise which was generated before.
Also the original frequency of the sample is ignored as target frequency as for ProTracker only certain base frequencies can be used.

I hope this is satisfying to you. I haven't programmed C# for about 10 years and my experiences with MOD files might be not as much as you have.

Tested with:
mono Xrns2XModShell.exe resources/examples/test_mod_sample_conversion.xrns -t mod --out test.mod
